### PR TITLE
Simplify SSHing into client hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ ok: [localhost] => (item=54.212.205.198) => {
 You can SSH into the machine where the benchmark client was installed:
 
 ```shell
-ssh ec2-user@${CLIENT_IP}
+ssh ec2-user@$(terraform output client_ssh_host)
 ```
 
-Start the load
+Start the load:
 
 ```shell
 cd /opt/benchmark

--- a/driver-kafka/deploy/ansible.cfg
+++ b/driver-kafka/deploy/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+host_key_checking=false
+private_key_file=~/.ssh/id_rsa
+
+[privilege_escalation]
+become=true
+become_method='sudo'
+become_user='root'

--- a/driver-kafka/deploy/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/provision-kafka-aws.tf
@@ -1,10 +1,11 @@
 variable "public_key_path" {
+  default = "~/.ssh/id_rsa.pub"
   description = <<DESCRIPTION
 Path to the SSH public key to be used for authentication.
 Ensure this keypair is added to your local SSH agent so provisioners can
 connect.
 
-Example: ~/.ssh/terraform.pub
+Example: ~/.ssh/id_rsa.pub
 DESCRIPTION
 }
 

--- a/driver-kafka/deploy/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/provision-kafka-aws.tf
@@ -129,3 +129,7 @@ resource "aws_instance" "client" {
         Name = "kafka-client-${count.index}"
     }
 }
+
+output "client_ssh_host" {
+  value = "${aws_instance.client.0.public_ip}"
+}

--- a/driver-pulsar/deploy/ansible.cfg
+++ b/driver-pulsar/deploy/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+host_key_checking=false
+private_key_file=~/.ssh/id_rsa
+
+[privilege_escalation]
+become=true
+become_method='sudo'
+become_user='root'

--- a/driver-pulsar/deploy/deploy.yaml
+++ b/driver-pulsar/deploy/deploy.yaml
@@ -23,7 +23,7 @@
   become: true
   tasks:
     - shell: >
-        sudo tuned-adm profile latency-performance &&
+        tuned-adm profile latency-performance &&
         mkfs.xfs /dev/nvme0n1 &&
         mkfs.xfs /dev/nvme1n1 &&
         mkdir -p /mnt/journal &&
@@ -50,13 +50,14 @@
         zookeeperServers: "{{ groups['zookeeper']|map('extract', hostvars, ['ansible_default_ipv4', 'address'])|map('regex_replace', '(.*)', '\\1:2181') | join(',') }}"
         serviceUrl: "pulsar://{{ hostvars[groups['pulsar'][0]].private_ip }}:6650/"
         httpUrl: "http://{{ hostvars[groups['pulsar'][0]].private_ip }}:8080/"
+        pulsarVersion: "1.21.0-incubating"
 
     - name: Download Pulsar
       file:
         path: "/opt/pulsar"
         state: directory
     - get_url:
-        url: https://dist.apache.org/repos/dist/dev/incubator/pulsar/pulsar-1.21.0-incubating-candidate-3/apache-pulsar-1.21.0-incubating-bin.tar.gz
+        url: https://dist.apache.org/repos/dist/dev/incubator/pulsar/pulsar-{{ pulsarVersion }}-candidate-3/apache-pulsar-{{ pulsarVersion }}-bin.tar.gz
         dest: /tmp/pulsar.tgz
     - command: tar --strip-components=1 -xvf /tmp/pulsar.tgz
       args:
@@ -169,7 +170,7 @@
         src: ../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
     - shell: >
-        sudo tuned-adm profile latency-performance &&
+        tuned-adm profile latency-performance &&
         mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
     - name: Configure service URL
       lineinfile:
@@ -190,6 +191,7 @@
 
 - name:  Hosts addresses
   hosts: localhost
+  become: false
   tasks:
     - debug:
         msg: "Zookeeper servers  {{ item }}"

--- a/driver-pulsar/deploy/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/provision-pulsar-aws.tf
@@ -129,3 +129,7 @@ resource "aws_instance" "client" {
         Name = "pulsar-client-${count.index}"
     }
 }
+
+output "client_ssh_host" {
+  value = "${aws_instance.client.0.public_ip}"
+}

--- a/driver-pulsar/deploy/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/provision-pulsar-aws.tf
@@ -1,10 +1,11 @@
 variable "public_key_path" {
+  default = "~/.ssh/id_rsa.pub"
   description = <<DESCRIPTION
 Path to the SSH public key to be used for authentication.
 Ensure this keypair is added to your local SSH agent so provisioners can
 connect.
 
-Example: ~/.ssh/terraform.pub
+Example: ~/.ssh/id_rsa.pub
 DESCRIPTION
 }
 


### PR DESCRIPTION
This PR creates a Terraform [output](https://www.terraform.io/intro/getting-started/outputs.html) for both the Pulsar and Kafka setups that enables you to seamlessly SSH into the client hosts with a single command.