### PR TITLE
Alter Terraform config to allow for variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ core/*.json
 **/terraform.tfstate.backup
 **/*.lock.info
 .DS_Store
+*.iml
+.idea/

--- a/driver-kafka/README.md
+++ b/driver-kafka/README.md
@@ -34,7 +34,7 @@ In addition, you will need to:
 * [Install the `aws` CLI tool](https://aws.amazon.com/cli/)
 * [Configure the `aws` CLI tool](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
 
-Once those conditions are in place, you'll need to create an SSH public and private key at `~/.ssh/aws_pulsar` (private) and `~/.ssh/aws_pulsar.pub` (public), respectively.
+Once those conditions are in place, you'll need to create an SSH public and private key at `~/.ssh/kafka_aws` (private) and `~/.ssh/kafka_aws.pub` (public), respectively.
 
 ```bash
 $ ssh-keygen -f ~/.ssh/kafka_aws
@@ -63,6 +63,32 @@ Client instance | The VM from which the benchmarking suite itself will be run | 
 When you run `terraform apply`, you will be prompted to type `yes`. Type `yes` to continue with the installation or anything else to quit.
 
 Once the installation is complete, you will see a confirmation message listing the resources that have been installed.
+
+### Variables
+
+There's a handful of configurable parameters related to the Terraform deployment that you can alter by modifying the defaults in the `terraform.tfvars` file.
+
+Variable | Description | Default
+:--------|:------------|:-------
+`region` | The AWS region in which the Kafka cluster will be deployed | `us-west-2`
+`public_key_path` | The path to the SSH public key that you've generated | `~/.ssh/kafka_aws.pub`
+`ami` | The [Amazon Machine Image](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) (AWI) to be used by the cluster's machines | [`ami-9fa343e7`](https://access.redhat.com/articles/3135091)
+`instance_types` | The EC2 instance types used by the various components | `i3.4xlarge` (Kafka brokers), `t2.small` (ZooKeeper), `c4.8xlarge` (benchmarking client)
+
+> If you modify the `public_key_path`, make sure that you point to the appropriate SSH key path when running the [Ansible playbook](#running-the-ansible-playbook).
+
+### Running the Ansible playbook
+
+With the appropriate infrastructure in place, you can install and start the Kafka cluster using Ansible with just one command:
+
+```bash
+$ ansible-playbook \
+  --user ec2-user \
+  --inventory `which terraform-inventory` \
+  deploy.yaml
+```
+
+> If you're using an SSH private key path different from `~/.ssh/kafka_aws`, you can specify that path using the `--private-key` flag, for example `--private-key=~/.ssh/my_key`.
 
 ## SSHing into the client host
 

--- a/driver-kafka/deploy/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/provision-kafka-aws.tf
@@ -1,5 +1,4 @@
 variable "public_key_path" {
-  default = "~/.ssh/kafka_aws.pub"
   description = <<DESCRIPTION
 Path to the SSH public key to be used for authentication.
 Ensure this keypair is added to your local SSH agent so provisioners can
@@ -10,16 +9,16 @@ DESCRIPTION
 }
 
 variable "key_name" {
-  default = "kafka-benchmark-key"
+  default     = "kafka-benchmark-key"
   description = "Desired name of AWS key pair"
 }
 
-variable "region" {
-  default = "us-west-2"
-}
+variable "region" {}
 
-variable "ami" {
-  default = "ami-9fa343e7" // RHEL-7.4
+variable "ami" {}
+
+variable "instance_types" {
+  type = "map"
 }
 
 provider "aws" {
@@ -94,7 +93,7 @@ resource "aws_key_pair" "auth" {
 
 resource "aws_instance" "zookeeper" {
   ami           = "${var.ami}"
-  instance_type = "t2.small"
+  instance_type = "${var.instance_types["zookeeper"]}"
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
@@ -107,7 +106,7 @@ resource "aws_instance" "zookeeper" {
 
 resource "aws_instance" "kafka" {
   ami           = "${var.ami}"
-  instance_type = "i3.4xlarge"
+  instance_type = "${var.instance_types["kafka"]}"
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
@@ -120,7 +119,7 @@ resource "aws_instance" "kafka" {
 
 resource "aws_instance" "client" {
   ami           = "${var.ami}"
-  instance_type = "c4.8xlarge"
+  instance_type = "${var.instance_types["client"]}"
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]

--- a/driver-kafka/deploy/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/provision-kafka-aws.tf
@@ -82,7 +82,7 @@ resource "aws_security_group" "benchmark_security_group" {
   }
 
   tags {
-      Name = "Benchmark-Security-Group"
+    Name = "Benchmark-Security-Group"
   }
 }
 
@@ -97,7 +97,7 @@ resource "aws_instance" "zookeeper" {
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = 3
+  count         = "${var.num_instances["zookeeper"]}"
 
   tags {
     Name = "kafka-zk-${count.index}"
@@ -110,7 +110,7 @@ resource "aws_instance" "kafka" {
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = 3
+  count         = "${var.num_instances["kafka"]}"
 
   tags {
     Name = "kafka-${count.index}"

--- a/driver-kafka/deploy/provision-kafka-aws.tf
+++ b/driver-kafka/deploy/provision-kafka-aws.tf
@@ -54,8 +54,8 @@ resource "aws_subnet" "benchmark_subnet" {
 }
 
 resource "aws_security_group" "benchmark_security_group" {
-  name        = "terraform"
-  vpc_id      = "${aws_vpc.benchmark_vpc.id}"
+  name   = "terraform"
+  vpc_id = "${aws_vpc.benchmark_vpc.id}"
 
   # SSH access from anywhere
   ingress {
@@ -92,12 +92,12 @@ resource "aws_key_pair" "auth" {
 }
 
 resource "aws_instance" "zookeeper" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_types["zookeeper"]}"
-  key_name      = "${aws_key_pair.auth.id}"
-  subnet_id     = "${aws_subnet.benchmark_subnet.id}"
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_types["zookeeper"]}"
+  key_name               = "${aws_key_pair.auth.id}"
+  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = "${var.num_instances["zookeeper"]}"
+  count                  = "${var.num_instances["zookeeper"]}"
 
   tags {
     Name = "kafka-zk-${count.index}"
@@ -105,12 +105,12 @@ resource "aws_instance" "zookeeper" {
 }
 
 resource "aws_instance" "kafka" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_types["kafka"]}"
-  key_name      = "${aws_key_pair.auth.id}"
-  subnet_id     = "${aws_subnet.benchmark_subnet.id}"
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_types["kafka"]}"
+  key_name               = "${aws_key_pair.auth.id}"
+  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = "${var.num_instances["kafka"]}"
+  count                  = "${var.num_instances["kafka"]}"
 
   tags {
     Name = "kafka-${count.index}"
@@ -118,12 +118,12 @@ resource "aws_instance" "kafka" {
 }
 
 resource "aws_instance" "client" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_types["client"]}"
-  key_name      = "${aws_key_pair.auth.id}"
-  subnet_id     = "${aws_subnet.benchmark_subnet.id}"
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_types["client"]}"
+  key_name               = "${aws_key_pair.auth.id}"
+  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = 1
+  count                  = 1
 
   tags {
     Name = "kafka-client-${count.index}"

--- a/driver-kafka/deploy/terraform.tfvars
+++ b/driver-kafka/deploy/terraform.tfvars
@@ -1,0 +1,9 @@
+public_key_path = "~/.ssh/kafka_aws.pub"
+region          = "us-west-2"
+ami             = "ami-9fa343e7" // RHEL-7.4
+
+instance_types = {
+  "kafka"     = "i3.4xlarge"
+  "zookeeper" = "t2.small"
+  "client"    = "c4.8xlarge"
+}

--- a/driver-kafka/deploy/terraform.tfvars
+++ b/driver-kafka/deploy/terraform.tfvars
@@ -7,3 +7,8 @@ instance_types = {
   "zookeeper" = "t2.small"
   "client"    = "c4.8xlarge"
 }
+
+num_instances = {
+  "kafka"     = 3
+  "zookeeper" = 3
+}

--- a/driver-pulsar/README.md
+++ b/driver-pulsar/README.md
@@ -64,6 +64,32 @@ When you run `terraform apply`, you will be prompted to type `yes`. Type `yes` t
 
 Once the installation is complete, you will see a confirmation message listing the resources that have been installed.
 
+### Variables
+
+There's a handful of configurable parameters related to the Terraform deployment that you can alter by modifying the defaults in the `terraform.tfvars` file.
+
+Variable | Description | Default
+:--------|:------------|:-------
+`region` | The AWS region in which the Pulsar cluster will be deployed | `us-west-2`
+`public_key_path` | The path to the SSH public key that you've generated | `~/.ssh/pulsar_aws.pub`
+`ami` | The [Amazon Machine Image](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) (AWI) to be used by the cluster's machines | [`ami-9fa343e7`](https://access.redhat.com/articles/3135091)
+`instance_types` | The EC2 instance types used by the various components | `i3.4xlarge` (Pulsar brokers and BookKeeper bookies), `t2.small` (ZooKeeper), `c4.8xlarge` (benchmarking client)
+
+> If you modify the `public_key_path`, make sure that you point to the appropriate SSH key path when running the [Ansible playbook](#running-the-ansible-playbook).
+
+### Running the Ansible playbook
+
+With the appropriate infrastructure in place, you can install and start the Pulsar cluster using Ansible with just one command:
+
+```bash
+$ ansible-playbook \
+  --user ec2-user \
+  --inventory `which terraform-inventory` \
+  deploy.yaml
+```
+
+> If you're using an SSH private key path different from `~/.ssh/pulsar_aws`, you can specify that path using the `--private-key` flag, for example `--private-key=~/.ssh/my_key`.
+
 ## SSHing into the client host
 
 In the [output](https://www.terraform.io/intro/getting-started/outputs.html) produced by Terraform, there's a `client_ssh_host` variable that provides the IP address for the client EC2 host from which benchmarks can be run. You can SSH into that host using this command:

--- a/driver-pulsar/deploy/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/provision-pulsar-aws.tf
@@ -1,25 +1,24 @@
 variable "public_key_path" {
-  default = "~/.ssh/pulsar_aws.pub"
   description = <<DESCRIPTION
 Path to the SSH public key to be used for authentication.
 Ensure this keypair is added to your local SSH agent so provisioners can
 connect.
 
-Example: ~/.ssh/terraform_pulsar.pub
+Example: ~/.ssh/pulsar_aws.pub
 DESCRIPTION
 }
 
 variable "key_name" {
-  default = "pulsar-benchmark-key"
+  default     = "pulsar-benchmark-key"
   description = "Desired name of AWS key pair"
 }
 
-variable "region" {
-  default = "us-west-2"
-}
+variable "region" {}
 
-variable "ami" {
-  default = "ami-9fa343e7" // RHEL-7.4
+variable "ami" {}
+
+variable "instance_types" {
+  type = "map"
 }
 
 provider "aws" {
@@ -94,7 +93,7 @@ resource "aws_key_pair" "auth" {
 
 resource "aws_instance" "zookeeper" {
   ami           = "${var.ami}"
-  instance_type = "t2.small"
+  instance_type = "${var.instance_types["zookeeper"]}"
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
@@ -107,7 +106,7 @@ resource "aws_instance" "zookeeper" {
 
 resource "aws_instance" "pulsar" {
   ami           = "${var.ami}"
-  instance_type = "i3.4xlarge"
+  instance_type = "${var.instance_types["pulsar"]}"
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
@@ -120,7 +119,7 @@ resource "aws_instance" "pulsar" {
 
 resource "aws_instance" "client" {
   ami           = "${var.ami}"
-  instance_type = "c4.8xlarge"
+  instance_type = "${var.instance_types["client"]}"
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]

--- a/driver-pulsar/deploy/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/provision-pulsar-aws.tf
@@ -54,8 +54,8 @@ resource "aws_subnet" "benchmark_subnet" {
 }
 
 resource "aws_security_group" "benchmark_security_group" {
-  name        = "terraform"
-  vpc_id      = "${aws_vpc.benchmark_vpc.id}"
+  name   = "terraform"
+  vpc_id = "${aws_vpc.benchmark_vpc.id}"
 
   # SSH access from anywhere
   ingress {
@@ -92,12 +92,12 @@ resource "aws_key_pair" "auth" {
 }
 
 resource "aws_instance" "zookeeper" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_types["zookeeper"]}"
-  key_name      = "${aws_key_pair.auth.id}"
-  subnet_id     = "${aws_subnet.benchmark_subnet.id}"
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_types["zookeeper"]}"
+  key_name               = "${aws_key_pair.auth.id}"
+  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = "${var.num_instances["zookeeper"]}"
+  count                  = "${var.num_instances["zookeeper"]}"
 
   tags {
     Name = "zk-${count.index}"
@@ -105,12 +105,12 @@ resource "aws_instance" "zookeeper" {
 }
 
 resource "aws_instance" "pulsar" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_types["pulsar"]}"
-  key_name      = "${aws_key_pair.auth.id}"
-  subnet_id     = "${aws_subnet.benchmark_subnet.id}"
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_types["pulsar"]}"
+  key_name               = "${aws_key_pair.auth.id}"
+  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = "${var.num_instances["pulsar"]}"
+  count                  = "${var.num_instances["pulsar"]}"
 
   tags {
     Name = "pulsar-${count.index}"
@@ -118,12 +118,12 @@ resource "aws_instance" "pulsar" {
 }
 
 resource "aws_instance" "client" {
-  ami           = "${var.ami}"
-  instance_type = "${var.instance_types["client"]}"
-  key_name      = "${aws_key_pair.auth.id}"
-  subnet_id     = "${aws_subnet.benchmark_subnet.id}"
+  ami                    = "${var.ami}"
+  instance_type          = "${var.instance_types["client"]}"
+  key_name               = "${aws_key_pair.auth.id}"
+  subnet_id              = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = 1
+  count                  = 1
 
   tags {
     Name = "pulsar-client-${count.index}"

--- a/driver-pulsar/deploy/provision-pulsar-aws.tf
+++ b/driver-pulsar/deploy/provision-pulsar-aws.tf
@@ -82,7 +82,7 @@ resource "aws_security_group" "benchmark_security_group" {
   }
 
   tags {
-      Name = "Benchmark-Security-Group"
+    Name = "Benchmark-Security-Group"
   }
 }
 
@@ -97,10 +97,10 @@ resource "aws_instance" "zookeeper" {
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = 3
+  count         = "${var.num_instances["zookeeper"]}"
 
   tags {
-      Name = "zk-${count.index}"
+    Name = "zk-${count.index}"
   }
 }
 
@@ -110,10 +110,10 @@ resource "aws_instance" "pulsar" {
   key_name      = "${aws_key_pair.auth.id}"
   subnet_id     = "${aws_subnet.benchmark_subnet.id}"
   vpc_security_group_ids = ["${aws_security_group.benchmark_security_group.id}"]
-  count         = 3
+  count         = "${var.num_instances["pulsar"]}"
 
   tags {
-      Name = "pulsar-${count.index}"
+    Name = "pulsar-${count.index}"
   }
 }
 
@@ -126,7 +126,7 @@ resource "aws_instance" "client" {
   count         = 1
 
   tags {
-      Name = "pulsar-client-${count.index}"
+    Name = "pulsar-client-${count.index}"
   }
 }
 

--- a/driver-pulsar/deploy/terraform.tfvars
+++ b/driver-pulsar/deploy/terraform.tfvars
@@ -7,3 +7,8 @@ instance_types = {
   "zookeeper" = "t2.small"
   "client"    = "c4.8xlarge"
 }
+
+num_instances = {
+  "pulsar"    = 3
+  "zookeeper" = 3
+}

--- a/driver-pulsar/deploy/terraform.tfvars
+++ b/driver-pulsar/deploy/terraform.tfvars
@@ -1,0 +1,9 @@
+public_key_path = "~/.ssh/pulsar_aws.pub"
+region          = "us-west-2"
+ami             = "ami-9fa343e7" // RHEL-7.4
+
+instance_types = {
+  "pulsar"    = "i3.4xlarge"
+  "zookeeper" = "t2.small"
+  "client"    = "c4.8xlarge"
+}


### PR DESCRIPTION
This PR makes a few changes:

* Adds a handful of variables to the Terraform configs (AWS region, instance types, number of instances of ZK/Pulsar/Kafka, etc.) and stores the defaults in a `.tfvars` file (users can change values if they wish to alter the Terraform setup).
* Adds some missing docs re: Ansible deployment to the Kafka and Pulsar READMEs.